### PR TITLE
Update runtime to 25.08

### DIFF
--- a/dev.overlayed.Overlayed.yaml
+++ b/dev.overlayed.Overlayed.yaml
@@ -1,7 +1,7 @@
 id: dev.overlayed.Overlayed
 
-runtime: org.freedesktop.Sdk
-runtime-version: '23.08'
+runtime: org.freedesktop.Platform
+runtime-version: '25.08'
 sdk: org.freedesktop.Sdk
 command: overlayed
 finish-args:


### PR DESCRIPTION
- Update runtime to 25.08
- Use the Freedesktop Platform instead of the SDK