### PR TITLE
Fixing the tray icon

### DIFF
--- a/dev.overlayed.Overlayed.yaml
+++ b/dev.overlayed.Overlayed.yaml
@@ -11,6 +11,7 @@ finish-args:
   - --share=network
   - --socket=pulseaudio
   - --talk-name=org.freedesktop.Notifications
+  - --talk-name=org.kde.StatusNotifierWatcher
 
 modules:
   - name: webkit2gtk-4.1


### PR DESCRIPTION
In order to display the tray icon the StatusNotifierWatcher permission is needed