### PR TITLE
Ensure overlayed stays on top

### DIFF
--- a/dev.overlayed.Overlayed.yaml
+++ b/dev.overlayed.Overlayed.yaml
@@ -5,8 +5,8 @@ runtime-version: '23.08'
 sdk: org.freedesktop.Sdk
 command: overlayed
 finish-args:
-  - --socket=wayland
-  - --socket=fallback-x11
+  - --socket=x11
+  - --env=GDK_BACKEND=x11
   - --share=ipc
   - --share=network
   - --socket=pulseaudio


### PR DESCRIPTION
To ensure that the overlayed window stays on top of other windows it needs to run via XWayland