### PR TITLE
Update runtime to newer version

### DIFF
--- a/dev.overlayed.Overlayed.yaml
+++ b/dev.overlayed.Overlayed.yaml
@@ -1,7 +1,7 @@
 id: dev.overlayed.Overlayed
 
-runtime: org.freedesktop.Sdk
-runtime-version: '23.08'
+runtime: org.freedesktop.Platform
+runtime-version: '24.08'
 sdk: org.freedesktop.Sdk
 command: overlayed
 finish-args:


### PR DESCRIPTION
Version 24.08 is still supported until 2026-08-30. Version 25.08 has some bigger changes and may need some adjustments. Changed the runtime to use the Platform since normal users don't need all the dev dependencies from the Sdk.